### PR TITLE
Fix reel scroll precision and icon selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -826,7 +826,10 @@
         }
       }
 
+      let snapping = false;
       function snap(dist){
+        if(snapping) return;
+        snapping = true;
         const start = frac;
         const end = start + dist;
         const t0 = performance.now();
@@ -839,6 +842,7 @@
           if(p<1) requestAnimationFrame(step); else{
             index = (Math.round(index + dist) % rows + rows) % rows;
             frac = 0;
+            snapping = false;
             render();
           }
         }
@@ -892,8 +896,10 @@
         t.addEventListener('click',()=>{
           const row = Math.floor(i/cols);
           colIdx = i % cols;
-          const diff = row - index;
-          snap(diff);
+          let diff = row - index;
+          diff = ((diff % rows) + rows) % rows;
+          if(diff > rows/2) diff -= rows;
+          if(diff) snap(diff);
           selectCurrent();
           if(t.dataset.game){ openGame(t); }
         });


### PR DESCRIPTION
## Summary
- prevent extra snap animations for smoother single-step scrolling
- avoid full-spin when selecting tiles by shortest path calculation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adec524a9083328e66285fca90e512