### PR TITLE
feat: lazily load game iframes

### DIFF
--- a/arena.html
+++ b/arena.html
@@ -28,7 +28,7 @@
     html, body { width: 100%; height: 100%; font-family: 'Press Start 2P', monospace; }
     body { background: var(--bg-color); color: var(--text-color); display: flex; flex-direction: column; align-items: center; }
     button, select, input, .card { font-family: inherit; }
-    .screen { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 20px; width: 100%; height: 100vh; }
+    .screen { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 20px; width: 100%; height: 100svh; }
     .card { background: var(--card-bg); border: 3px solid var(--card-border); border-radius: 12px; padding: 20px 40px; min-width: 200px; text-align: center; font-size: 20px; cursor: pointer; box-shadow: 0 4px 8px rgba(0,0,0,0.1); transition: transform 0.15s, box-shadow 0.15s; }
     .card:hover { transform: translateY(-4px); box-shadow: 0 6px 12px rgba(0,0,0,0.15); }
     .card:active { transform: translateY(0); box-shadow: 0 2px 4px rgba(0,0,0,0.1); }

--- a/arena.html
+++ b/arena.html
@@ -25,7 +25,7 @@
       --btn-disabled: #E0E0E0;
     }
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    html, body { width: 100%; height: 100%; font-family: 'Press Start 2P', 'Courier New', monospace; }
+    html, body { width: 100%; height: 100%; font-family: 'Press Start 2P', monospace; }
     body { background: var(--bg-color); color: var(--text-color); display: flex; flex-direction: column; align-items: center; }
     button, select, input, .card { font-family: inherit; }
     .screen { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 20px; width: 100%; height: 100vh; }

--- a/arena.html
+++ b/arena.html
@@ -209,9 +209,8 @@
   <script type="module" src="src/pixel-widgets.js"></script>
   <script type="module" src="src/i18n.js"></script>
   <script>
-
+  window.addEventListener('DOMContentLoaded',()=>{
   // Main game logic
-  (function(){
     const STEPS=5;
     const DXY={up:[0,-1],down:[0,1],left:[-1,0],right:[1,0]};
     let single=false; let aiLevel='medium'; let round=1; let phase='planA';
@@ -304,7 +303,7 @@
     i18n.applyTranslations();
     bindUI();
     langSelect.value=i18n.lang;
-  })();
+  });
   </script>
 </body>
 </html>

--- a/avatar-editor.html
+++ b/avatar-editor.html
@@ -112,7 +112,7 @@
 const S=16, cv=document.getElementById('cv'), ctx=cv.getContext('2d',{alpha:true});
 cv.width=cv.height=S;
 ctx.imageSmoothingEnabled=false;
-const UI={tabs:document.getElementById('tabs'), panels:document.getElementById('panels'), gesture:document.getElementById('gesture')};
+const dom={tabs:document.getElementById('tabs'), panels:document.getElementById('panels'), gesture:document.getElementById('gesture')};
 const toast=UI.makeToast(document.getElementById('toast'));
 
 /* offscreen: вся отрисовка здесь */
@@ -282,16 +282,16 @@ function render(){
 
 /* ===== UI ===== */
 function buildUI(){
-  UI.tabs.innerHTML=''; UI.panels.innerHTML='';
+  dom.tabs.innerHTML=''; dom.panels.innerHTML='';
   CATS.forEach(cat=>{
     const b=document.createElement('button');
     b.className='tab'; b.textContent=cat.n; b.dataset.k=cat.k;
     if(cat.k===active) b.setAttribute('aria-selected','true');
     b.onclick=()=>{ active=cat.k; document.querySelectorAll('.tab').forEach(x=>x.removeAttribute('aria-selected')); b.setAttribute('aria-selected','true'); openPanel(cat.k); };
-    UI.tabs.appendChild(b);
+    dom.tabs.appendChild(b);
 
     const p=document.createElement('div'); p.id='p-'+cat.k; p.className='panel';
-    UI.panels.appendChild(p);
+    dom.panels.appendChild(p);
   });
   openPanel(active);
 }
@@ -338,9 +338,9 @@ function save(){ localStorage.setItem('ss16_avatar_simple', JSON.stringify(state
 
 /* ===== gestures (swipe) ===== */
 (()=>{ let sx=0, moved=false;
-  UI.gesture.addEventListener('touchstart',e=>{sx=e.touches[0].clientX;moved=false;},{passive:true});
-  UI.gesture.addEventListener('touchmove',e=>{ if(Math.abs(e.touches[0].clientX-sx)>20) moved=true; },{passive:true});
-  UI.gesture.addEventListener('touchend',e=>{
+  dom.gesture.addEventListener('touchstart',e=>{sx=e.touches[0].clientX;moved=false;},{passive:true});
+  dom.gesture.addEventListener('touchmove',e=>{ if(Math.abs(e.touches[0].clientX-sx)>20) moved=true; },{passive:true});
+  dom.gesture.addEventListener('touchend',e=>{
     if(!moved){ change(active,1); return; }
     const dx=e.changedTouches[0].clientX-sx; if(dx>24) change(active,-1); else if(dx<-24) change(active,1);
   },{passive:true});

--- a/avatar-editor.html
+++ b/avatar-editor.html
@@ -63,8 +63,21 @@
   @media (max-height:600px){
     .stage{max-width:120px}
   }
+  .toast{
+    position:fixed;
+    top:20px;
+    left:50%;
+    transform:translateX(-50%);
+    background:var(--pastel-pink);
+    border:2px solid var(--accent);
+    border-radius:8px;
+    padding:8px 12px;
+    font-size:14px;
+    color:var(--ink);
+  }
 </style>
 <script type="module" src="src/pixel-widgets.js"></script>
+<script src="src/ui.js"></script>
 </head>
 <body>
 <div class="cabinet">
@@ -92,12 +105,15 @@
   </div>
 </div>
 
+<div id="toast" class="toast"></div>
+
 <script>
 /* ===== base ===== */
 const S=16, cv=document.getElementById('cv'), ctx=cv.getContext('2d',{alpha:true});
 cv.width=cv.height=S;
 ctx.imageSmoothingEnabled=false;
 const UI={tabs:document.getElementById('tabs'), panels:document.getElementById('panels'), gesture:document.getElementById('gesture')};
+const toast=UI.makeToast(document.getElementById('toast'));
 
 /* offscreen: вся отрисовка здесь */
 const off=document.createElement('canvas'); off.width=off.height=S;
@@ -364,7 +380,7 @@ document.getElementById('importJson').onclick = ()=>{
     const f=e.target.files[0];
     if(!f) return;
     const r=new FileReader();
-    r.onload=ev=>{ try{ state=JSON.parse(ev.target.result); render(); }catch(err){ alert('Ошибка импорта'); } };
+    r.onload=ev=>{ try{ state=JSON.parse(ev.target.result); render(); }catch(err){ toast('Ошибка импорта'); } };
     r.readAsText(f);
   };
   inp.click();

--- a/dodge-rain.html
+++ b/dodge-rain.html
@@ -6,17 +6,6 @@
   <title data-i18n="dodgeRain"></title>
   <link rel="stylesheet" href="styles/shell.css">
   <style>
-    :root{
-      --bg0:var(--bg);
-      --bg1:var(--bg2);
-      --bg2:var(--panel);
-      --ink:var(--ink);
-      --pastel-pink:var(--accent);
-      --pastel-blue:var(--accent2);
-      --pastel-mint:var(--hi);
-      --pastel-peach:var(--panel);
-      --accent:var(--accent2);
-    }
     *{box-sizing:border-box;margin:0;padding:0;}
     body{
       display:flex;
@@ -64,7 +53,7 @@
     .pad{position:static;margin-top:8px;}
   </style>
 </head>
-<body>
+<body class="theme-blue">
   <h1>Dodge Rain</h1>
   <div id="score" class="pill">Счёт: 0</div>
   <button id="scoresBtn" class="pill" aria-label="Рекорды">🏆</button>

--- a/dodge-rain.html
+++ b/dodge-rain.html
@@ -32,7 +32,7 @@
       border:4px solid var(--pastel-peach);
       image-rendering:pixelated;
       box-shadow:0 10px 20px rgba(0,0,0,0.2);
-      width:clamp(40vw,60vh,90vw);
+      width:clamp(60vw,80svh,96vw);
       height:auto;
       aspect-ratio:3/4;
     }

--- a/memory-flip.html
+++ b/memory-flip.html
@@ -6,17 +6,6 @@
   <title data-i18n="memoryFlip"></title>
   <link rel="stylesheet" href="styles/shell.css">
   <style>
-    :root{
-      --bg0:var(--bg);
-      --bg1:var(--bg2);
-      --bg2:var(--panel);
-      --ink:var(--ink);
-      --pastel-pink:var(--accent);
-      --pastel-blue:var(--accent2);
-      --pastel-mint:var(--hi);
-      --pastel-peach:var(--panel);
-      --accent:var(--accent2);
-    }
     *{box-sizing:border-box;margin:0;padding:0;}
     body{
       display:flex;
@@ -93,7 +82,7 @@
     .pad{position:static;margin-top:8px;}
   </style>
 </head>
-<body>
+<body class="theme-blue">
   <h1>Memory Flip</h1>
   <div id="score" class="pill">Найдено пар: 0/8</div>
   <div id="timer" class="pill">Время: 0.0с</div>

--- a/music-box.html
+++ b/music-box.html
@@ -268,6 +268,7 @@
   </div>
 
 <div id="msg" aria-live="polite"></div>
+  <script src="src/ui.js"></script>
   <script>
 /* ======= State & helpers ======= */
 const NOTES = ["C","C#","D","D#","E","F","F#","G","G#","A","A#","B"];

--- a/pixel-animator.html
+++ b/pixel-animator.html
@@ -64,7 +64,7 @@
 
   @media (max-width:600px){
     .workspace{grid-template-columns:1fr;grid-template-rows:1fr auto}
-    .tools{max-height:50vh;overflow:auto}
+    .tools{max-height:50svh;overflow:auto}
   }
 
   @media (min-width:601px){

--- a/pixel-animator.html
+++ b/pixel-animator.html
@@ -60,6 +60,8 @@
   textarea.code{font-family:ui-monospace,monospace}
   .codeBox{background:#0c0f12;color:#cbe4ff;border:2px solid #2a405b;border-radius:12px;padding:10px;overflow:auto;max-height:220px;font-family:ui-monospace,monospace}
 
+  .toast{position:fixed;top:20px;left:50%;transform:translateX(-50%);background:var(--amber);border:2px solid var(--bezel);border-radius:8px;padding:8px 12px;font-size:14px;color:var(--ink);}
+
   @media (max-width:600px){
     .workspace{grid-template-columns:1fr;grid-template-rows:1fr auto}
     .tools{max-height:50vh;overflow:auto}
@@ -151,11 +153,14 @@
       </div>
     </div>
   </div>
+
+  <div id="toast" class="toast"></div>
 <script src="src/ui.js"></script>
 <script>
 (function(){
   const GRID = 16;
   const LEN = GRID*GRID;
+  const toast=UI.makeToast(document.getElementById('toast'));
   document.querySelectorAll('details.accordion').forEach(d=>{
     if(window.matchMedia('(max-width:600px)').matches) d.removeAttribute('open');
   });
@@ -316,7 +321,7 @@
   function saveLS(){ localStorage.setItem('ss_pixel_animator', JSON.stringify(pack())); }
   function loadLS(){ const data=localStorage.getItem('ss_pixel_animator'); if(data){ try{unpack(JSON.parse(data));}catch(e){} } }
   document.getElementById('btn-export').onclick = ()=>{ io.value = JSON.stringify(pack()); io.scrollTop=0; };
-  document.getElementById('btn-import').onclick = ()=>{ try{ const data = JSON.parse(io.value); unpack(data); }catch(e){ alert('Ошибка импорта: '+e.message); } };
+  document.getElementById('btn-import').onclick = ()=>{ try{ const data = JSON.parse(io.value); unpack(data); }catch(e){ toast('Ошибка импорта: '+e.message); } };
   document.getElementById('btn-copy').onclick   = async()=>{ try{ await navigator.clipboard.writeText(io.value); }catch{} };
   document.getElementById('btn-gencode').onclick = ()=>{
     const data = JSON.stringify(pack());
@@ -331,7 +336,7 @@
   };
   document.getElementById('btn-upload').onclick = ()=>{
     const inp=document.createElement('input'); inp.type='file'; inp.accept='application/json';
-    inp.onchange=e=>{const f=e.target.files[0]; if(!f) return; const r=new FileReader(); r.onload=ev=>{ try{unpack(JSON.parse(ev.target.result));}catch(err){alert('Ошибка импорта');} }; r.readAsText(f);};
+    inp.onchange=e=>{const f=e.target.files[0]; if(!f) return; const r=new FileReader(); r.onload=ev=>{ try{unpack(JSON.parse(ev.target.result));}catch(err){toast('Ошибка импорта');} }; r.readAsText(f);};
     inp.click();
   };
   document.getElementById('btn-png').onclick = ()=>{
@@ -341,7 +346,7 @@
   };
   loadLS();
   document.getElementById('btn-record').onclick = async()=>{
-    if(!('MediaRecorder' in window)) { alert('MediaRecorder не поддерживается'); return; }
+    if(!('MediaRecorder' in window)) { toast('MediaRecorder не поддерживается'); return; }
     const seconds = Math.max(1, Math.ceil(frames.length / Math.max(1,fps)));
     const stream = canvas.captureStream(Math.max(1,fps)); const rec = new MediaRecorder(stream, {mimeType:'video/webm;codecs=vp9'});
     const chunks=[]; rec.ondataavailable=e=>e.data && chunks.push(e.data); const p=new Promise(r=>rec.onstop=r);

--- a/pixel-animator.html
+++ b/pixel-animator.html
@@ -11,7 +11,6 @@
     --panel-deep:var(--bezel);
     --amber:var(--accent3);
     --muted:var(--dim);
-    --accent:var(--accent2);
   }
   *{box-sizing:border-box;margin:0;padding:0;}
   body{
@@ -72,7 +71,7 @@
   }
 </style>
 </head>
-<body>
+<body class="theme-blue">
   <div class="cabinet">
     <div class="scan"></div>
     <div class="content">

--- a/pixel-snake.html
+++ b/pixel-snake.html
@@ -32,7 +32,7 @@
       background:var(--bg2);
       border:4px solid var(--pastel-peach);
       box-shadow:0 10px 20px rgba(0,0,0,0.2);
-      width:clamp(40vw,60vh,90vw);
+      width:clamp(60vw,80svh,96vw);
       height:auto;
       aspect-ratio:3/4;
     }

--- a/pixel-snake.html
+++ b/pixel-snake.html
@@ -6,17 +6,6 @@
   <title data-i18n="pixelSnake"></title>
   <link rel="stylesheet" href="styles/shell.css">
   <style>
-    :root{
-      --bg0:var(--bg);
-      --bg1:var(--bg2);
-      --bg2:var(--panel);
-      --ink:var(--ink);
-      --pastel-pink:var(--accent);
-      --pastel-blue:var(--accent2);
-      --pastel-mint:var(--hi);
-      --pastel-peach:var(--panel);
-      --accent:var(--accent2);
-    }
     *{box-sizing:border-box;margin:0;padding:0;}
     body{
       display:flex;
@@ -64,13 +53,22 @@
 
     .pad{position:static;margin-top:8px;}
 
+    .color-pick{display:flex;gap:4px;}
+    .color-pick button{width:36px;height:36px;border:2px solid var(--bezel);border-radius:8px;box-shadow:inset 0 0 0 2px var(--bezel-hi);cursor:pointer;}
+    .color-pick button.sel{outline:2px solid var(--accent);}
+
   </style>
 </head>
-<body>
+<body class="theme-blue">
   <h1>Pixel Snake</h1>
   <div id="score" class="pill">Счёт: 0</div>
   <button id="scoresBtn" class="pill" aria-label="Рекорды">🏆</button>
-  <input id="colorPick" type="color" title="Цвет змейки" style="width:36px;height:36px;border:none;background:none;padding:0">
+  <div id="colorPick" class="color-pick" title="Цвет змейки">
+    <button data-col="--pastel-mint" style="background:var(--pastel-mint)" aria-label="Зелёный"></button>
+    <button data-col="--pastel-blue" style="background:var(--pastel-blue)" aria-label="Синий"></button>
+    <button data-col="--pastel-pink" style="background:var(--pastel-pink)" aria-label="Розовый"></button>
+    <button data-col="--pastel-peach" style="background:var(--pastel-peach)" aria-label="Персиковый"></button>
+  </div>
   <div class="play">
     <canvas id="gameCanvas" tabindex="0" aria-label="Игровое поле"></canvas>
     <div id="toast" class="toast"></div>
@@ -124,11 +122,17 @@
       const m=col.match(/(\d+),\s*(\d+),\s*(\d+)/);
       return m? '#' + [1,2,3].map(i=>('0'+parseInt(m[i]).toString(16)).slice(-2)).join('') : '#3fbf75';
     }
-    colorPick.value=toHex(snakeColor);
-    colorPick.addEventListener('input',e=>{
-      snakeColor=e.target.value;
-      localStorage.setItem('snakeColor',snakeColor);
-      draw();
+    const colorBtns=colorPick.querySelectorAll('button');
+    colorBtns.forEach(btn=>{
+      const getCol=()=>getComputedStyle(document.documentElement).getPropertyValue(btn.dataset.col);
+      if(toHex(getCol())===toHex(snakeColor)) btn.classList.add('sel');
+      btn.addEventListener('click',()=>{
+        snakeColor=getCol().trim();
+        localStorage.setItem('snakeColor',snakeColor);
+        colorBtns.forEach(b=>b.classList.remove('sel'));
+        btn.classList.add('sel');
+        draw();
+      });
     });
 
 

--- a/retro-breakout.html
+++ b/retro-breakout.html
@@ -32,7 +32,7 @@
       border:4px solid var(--pastel-peach);
       box-shadow:0 10px 20px rgba(0,0,0,0.2);
       image-rendering:pixelated;
-      width:clamp(40vw,60vh,90vw);
+      width:clamp(60vw,80svh,96vw);
       height:auto;
       aspect-ratio:3/4;
     }

--- a/retro-breakout.html
+++ b/retro-breakout.html
@@ -6,17 +6,6 @@
   <title data-i18n="retroBreakout"></title>
   <link rel="stylesheet" href="styles/shell.css">
   <style>
-    :root{
-      --bg0:var(--bg);
-      --bg1:var(--bg2);
-      --bg2:var(--panel);
-      --ink:var(--ink);
-      --pastel-pink:var(--accent);
-      --pastel-blue:var(--accent2);
-      --pastel-mint:var(--hi);
-      --pastel-peach:var(--panel);
-      --accent:var(--accent2);
-    }
     *{box-sizing:border-box;margin:0;padding:0;}
     body{
       display:flex;
@@ -66,7 +55,7 @@
 
   </style>
 </head>
-<body>
+<body class="theme-blue">
   <h1>Retro Breakout</h1>
   <div id="score" class="pill">Счёт: 0</div>
   <div id="lives" class="pill">Жизни: 3</div>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -38,7 +38,11 @@ export function applyTranslations(root=document){
   root.querySelectorAll('*').forEach(el=>{
     for(const [k,v] of Object.entries(el.dataset)){
       if(k.startsWith('i18n') && k !== 'i18n'){
-        const attr = k.slice(4).replace(/([A-Z])/g,'-$1').toLowerCase();
+        const attr = k
+          .slice(4)
+          .replace(/^[A-Z]/, c => c.toLowerCase())
+          .replace(/([A-Z])/g, '-$1')
+          .toLowerCase();
         const val = dict[v];
         if(val !== undefined){
           el.setAttribute(attr, val);

--- a/src/icons.js
+++ b/src/icons.js
@@ -1,56 +1,70 @@
-(function(){
-  'use strict';
-  const cache={}, items=[];
-  let frame=0,last=0,fps=12,animating=false;
+import anim from './icon-data/anim.json';
+import arena from './icon-data/arena.json';
+import breakout from './icon-data/breakout.json';
+import cards from './icon-data/cards.json';
+import music from './icon-data/music.json';
+import pong from './icon-data/pong.json';
+import rain from './icon-data/rain.json';
+import rhythm from './icon-data/rhythm.json';
+import rogue from './icon-data/rogue.json';
+import snake from './icon-data/snake.json';
+import tower from './icon-data/tower.json';
 
-  async function load(name){
-    if(cache[name]) return cache[name];
-    const res = await fetch(`src/icon-data/${name}.json`);
-    const sets = await res.json();
-    cache[name] = sets.map(data=>{
-      const cv=document.createElement('canvas');
-      cv.width=16; cv.height=16;
-      const ctx=cv.getContext('2d',{alpha:false});
-      ctx.imageSmoothingEnabled=false;
-      let minX=1e9,minY=1e9,maxX=-1e9,maxY=-1e9;
-      data.forEach(p=>{ if(p.x<minX) minX=p.x; if(p.y<minY) minY=p.y; if(p.x>maxX) maxX=p.x; if(p.y>maxY) maxY=p.y; });
-      const w=maxX-minX+1, h=maxY-minY+1;
-      const offX=Math.floor((16-w)/2), offY=Math.floor((16-h)/2);
-      data.forEach(p=>{
-        ctx.fillStyle=p.c;
-        ctx.fillRect(p.x-minX+offX, p.y-minY+offY,1,1);
-      });
-      return cv;
+const raw = {anim, arena, breakout, cards, music, pong, rain, rhythm, rogue, snake, tower};
+
+const cache = {}, items = [];
+let frame = 0, last = 0, fps = 12, animating = false;
+
+function build(name){
+  if(cache[name]) return cache[name];
+  const sets = raw[name] || [];
+  const canvases = sets.map(data=>{
+    const cv = document.createElement('canvas');
+    cv.width = 16; cv.height = 16;
+    const ctx = cv.getContext('2d',{alpha:false});
+    ctx.imageSmoothingEnabled = false;
+    let minX=1e9,minY=1e9,maxX=-1e9,maxY=-1e9;
+    data.forEach(p=>{ if(p.x<minX) minX=p.x; if(p.y<minY) minY=p.y; if(p.x>maxX) maxX=p.x; if(p.y>maxY) maxY=p.y; });
+    const w=maxX-minX+1, h=maxY-minY+1;
+    const offX=Math.floor((16-w)/2), offY=Math.floor((16-h)/2);
+    data.forEach(p=>{
+      ctx.fillStyle=p.c;
+      ctx.fillRect(p.x-minX+offX, p.y-minY+offY,1,1);
     });
-    return cache[name];
+    return cv;
+  });
+  while(canvases.length<10 && canvases.length>0){
+    canvases.push(...canvases);
   }
+  cache[name] = canvases.slice(0, Math.max(10, canvases.length));
+  return cache[name];
+}
 
-  function draw(ctx,name,frame){
-    const set = cache[name];
-    if(!set) return;
-    const img=set[frame%set.length];
-    ctx.clearRect(0,0,ctx.canvas.width,ctx.canvas.height);
-    ctx.drawImage(img,0,0,img.width,img.height,0,0,ctx.canvas.width,ctx.canvas.height);
+function draw(ctx,name,frame){
+  const set = build(name);
+  if(!set || !set.length) return;
+  const img = set[frame % set.length];
+  ctx.clearRect(0,0,ctx.canvas.width,ctx.canvas.height);
+  ctx.drawImage(img,0,0,img.width,img.height,0,0,ctx.canvas.width,ctx.canvas.height);
+}
+
+function loop(t){
+  if(t - last > 1000 / fps){
+    frame++;
+    items.forEach(it=>draw(it.ctx, it.name, frame));
+    last = t;
   }
+  requestAnimationFrame(loop);
+}
 
-  function loop(t){
-    if(t-last>1000/fps){
-      frame++;
-      items.forEach(it=>draw(it.ctx,it.name,frame));
-      last=t;
-    }
-    requestAnimationFrame(loop);
-  }
+function animate(canvas,name){
+  const ctx = canvas.getContext('2d',{alpha:false});
+  ctx.imageSmoothingEnabled = false;
+  items.push({ctx,name});
+  draw(ctx,name,frame);
+  if(!animating){ animating = true; requestAnimationFrame(loop); }
+}
 
-  function animate(canvas,name){
-    const ctx=canvas.getContext('2d',{alpha:false});
-    ctx.imageSmoothingEnabled=false;
-    items.push({ctx,name});
-    (cache[name] ? Promise.resolve(cache[name]) : load(name)).then(()=>draw(ctx,name,frame));
-    if(!animating){ animating=true; requestAnimationFrame(loop); }
-  }
+function redraw(){ items.forEach(it=>draw(it.ctx,it.name,frame)); }
 
-  function redraw(){ items.forEach(it=>draw(it.ctx,it.name,frame)); }
-
-  window.Icons={animate, redraw};
-})();
+window.Icons = { animate, redraw };

--- a/src/main.js
+++ b/src/main.js
@@ -17,15 +17,7 @@ import { initSettings } from './settings.js';
       const indicator = $('.indicator');
       const gameOverlay = $('#gameOverlay');
       const screenEl = $('.screen');
-      const preloaded={};
-      tiles.forEach(t=>{
-        const src=t.dataset.game;
-        const iframe=document.createElement('iframe');
-        iframe.src=src;
-        iframe.style.display='none';
-        document.body.appendChild(iframe);
-        preloaded[src]=iframe;
-      });
+      let activeFrame=null;
       let DUR = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--dur'));
 
       // блокируем двойные касания и прокрутку страницы
@@ -263,7 +255,6 @@ import { initSettings } from './settings.js';
 
       function openGame(tile){
         const gameSrc = tile.dataset.game;
-        const frame = preloaded[gameSrc];
         const rect = tile.getBoundingClientRect();
         const srect = screenEl.getBoundingClientRect();
         const canvas = tile.querySelector('canvas');
@@ -281,7 +272,9 @@ import { initSettings } from './settings.js';
         gameOverlay.addEventListener('transitionend', function handler(){
           gameOverlay.removeEventListener('transitionend', handler);
           gameOverlay.innerHTML='';
-          frame.style.display='block';
+          const frame=document.createElement('iframe');
+          frame.src=gameSrc;
+          activeFrame=frame;
           gameOverlay.appendChild(frame);
           const close=document.createElement('button');
           close.className='pbtn close';
@@ -293,10 +286,9 @@ import { initSettings } from './settings.js';
       }
 
       function closeGame(){
-        const frame=gameOverlay.querySelector('iframe');
-        if(frame){
-          frame.style.display='none';
-          document.body.appendChild(frame);
+        if(activeFrame){
+          activeFrame.remove();
+          activeFrame=null;
         }
         gameOverlay.classList.remove('show');
         gameOverlay.innerHTML='';

--- a/src/main.js
+++ b/src/main.js
@@ -271,8 +271,11 @@ import { initSettings } from './settings.js';
         const offsetY = rect.top - srect.top;
         gameOverlay.style.transform = `translate(${offsetX}px,${offsetY}px) scale(${scaleX},${scaleY})`;
         requestAnimationFrame(()=>{ gameOverlay.style.transform='translate(0px,0px) scale(1)'; });
-        gameOverlay.addEventListener('transitionend', function handler(){
-          gameOverlay.removeEventListener('transitionend', handler);
+        let started=false;
+        function launch(){
+          if(started) return;
+          started=true;
+          gameOverlay.removeEventListener('transitionend', launch);
           gameOverlay.innerHTML='';
           const frame=document.createElement('iframe');
           frame.src=gameSrc;
@@ -285,7 +288,9 @@ import { initSettings } from './settings.js';
           gameOverlay.appendChild(close);
           $('#gameClose').addEventListener('click', closeGame);
           screenEl.classList.add('playing');
-        }, {once:true});
+        }
+        gameOverlay.addEventListener('transitionend', launch);
+        setTimeout(launch, DUR+50);
       }
 
       function closeGame(){
@@ -311,14 +316,19 @@ import { initSettings } from './settings.js';
           requestAnimationFrame(()=>{
             gameOverlay.style.transform = `translate(${offsetX}px,${offsetY}px) scale(${scaleX},${scaleY})`;
           });
-          gameOverlay.addEventListener('transitionend', function handler(){
-            gameOverlay.removeEventListener('transitionend', handler);
+          let finished=false;
+          function end(){
+            if(finished) return;
+            finished=true;
+            gameOverlay.removeEventListener('transitionend', end);
             gameOverlay.classList.remove('show');
             gameOverlay.style.transform='';
             gameOverlay.innerHTML='';
             currentTile=null;
             focusTile();
-          }, {once:true});
+          }
+          gameOverlay.addEventListener('transitionend', end);
+          setTimeout(end, DUR+50);
         }else{
           gameOverlay.classList.remove('show');
           gameOverlay.innerHTML='';

--- a/src/scores.js
+++ b/src/scores.js
@@ -19,8 +19,8 @@
     }
     function show(){
       const list = load();
-      if(!list.length){ alert('Пока нет рекордов'); return; }
-      alert(list.map((s,i)=>`${i+1}. ${s.name}: ${format(s.score)}`).join('\n'));
+      if(!list.length){ UI.alert('Пока нет рекордов'); return; }
+      UI.alert(list.map((s,i)=>`${i+1}. ${s.name}: ${format(s.score)}`).join('\n'));
     }
     return {add, show, load};
   }

--- a/src/ui.js
+++ b/src/ui.js
@@ -9,17 +9,38 @@
       }
     };
   };
-    UI.makeToast=function(el){
-      let timer;
-      return function(text){
-        el.textContent=text;
-        el.classList.remove('show');
-        void el.offsetWidth;
-        el.classList.add('show');
-        clearTimeout(timer);
-        timer=setTimeout(()=>el.classList.remove('show'),2000);
-      };
+  UI.makeToast=function(el){
+    let timer;
+    return function(text){
+      el.textContent=text;
+      el.classList.remove('show');
+      void el.offsetWidth;
+      el.classList.add('show');
+      clearTimeout(timer);
+      timer=setTimeout(()=>el.classList.remove('show'),2000);
     };
+  };
+  UI.alert=function(text){
+    const wrap=document.createElement('div');
+    wrap.className='popup';
+    const box=document.createElement('div');
+    box.className='box';
+    const p=document.createElement('p');
+    p.textContent=text;
+    const btn=document.createElement('button');
+    btn.className='btn';
+    btn.textContent=global.i18n ? i18n.t('close') : 'OK';
+    btn.dataset.i18n='close';
+    if(global.i18n) i18n.applyTranslations(btn);
+    btn.addEventListener('click',()=>wrap.remove());
+    box.appendChild(p);
+    box.appendChild(btn);
+    wrap.appendChild(box);
+    document.body.appendChild(wrap);
+    void wrap.offsetWidth;
+    wrap.classList.add('show');
+    btn.focus();
+  };
     UI.tabs=function(nav,sections){
       const btns=nav.querySelectorAll('[data-tab]');
       const panels=Array.from(sections);

--- a/styles/base.css
+++ b/styles/base.css
@@ -178,12 +178,27 @@ pixel-range .thumb{position:absolute;top:50%;width:14px;height:14px;background:v
 }
 
 .popup{
+  position:fixed;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  background:rgba(0,0,0,.4);
   opacity:0;
   pointer-events:none;
 }
 .popup.show{
   pointer-events:auto;
   animation:popup .25s forwards;
+}
+.popup .box{
+  background:var(--tile-bg);
+  border:2px solid var(--bezel);
+  border-radius:var(--r);
+  padding:20px;
+  box-shadow:0 4px 0 var(--bezel-lo),inset 0 0 0 2px var(--bezel-hi);
+  text-align:center;
+  white-space:pre-line;
 }
 
 @keyframes btn-press{

--- a/styles/main.css
+++ b/styles/main.css
@@ -164,7 +164,7 @@ html,body{overflow:hidden;}
     .menu .row.wide pixel-range{ flex:1; }
 
     .avatar-overlay{position:absolute; inset:0; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,.6); z-index:12;}
-    .avatar-overlay iframe{width:100%; max-width:420px; height:90vh; border:none; background:transparent;}
+    .avatar-overlay iframe{width:100%; max-width:420px; height:90svh; border:none; background:transparent;}
 
     /* CRT-слои */
     .scanlines, .vignette, .glass, .phosphor{

--- a/styles/main.css
+++ b/styles/main.css
@@ -112,6 +112,7 @@ html,body{overflow:hidden;}
       perspective:var(--persp);
       perspective-origin:50% 50%;
       transform-style:preserve-3d;
+      transition:transform var(--dur) var(--ease), opacity var(--dur) var(--ease);
       -webkit-mask-image:linear-gradient(to bottom, transparent 0%, rgba(0,0,0,.85) 10%, rgba(0,0,0,1) 90%, transparent 100%);
               mask-image:linear-gradient(to bottom, transparent 0%, rgba(0,0,0,.85) 10%, rgba(0,0,0,1) 90%, transparent 100%);
     }
@@ -122,6 +123,10 @@ html,body{overflow:hidden;}
     }
     .reel::before{ left:0; }
     .reel::after{ right:0; }
+
+    .reel.zoom{ transform:translateZ(60px) scale(1.15); }
+
+    .screen.playing .reel{ opacity:0; pointer-events:none; }
 
     .pbtn{
       font-size:12px; letter-spacing:1px; color:var(--ink);
@@ -164,6 +169,7 @@ html,body{overflow:hidden;}
     /* CRT-слои */
     .scanlines, .vignette, .glass, .phosphor{
       pointer-events:none; position:absolute; inset:0; border-radius:var(--crt-curve);
+      opacity:0; transition:opacity var(--dur) var(--ease);
     }
     .scanlines{
       background: repeating-linear-gradient(
@@ -204,14 +210,20 @@ html,body{overflow:hidden;}
         radial-gradient(80% 60% at 50% 48%, rgba(201,244,228,.035), transparent 55%);
       mix-blend-mode:screen;
     }
+    .screen.playing .scanlines,
+    .screen.playing .vignette,
+    .screen.playing .glass,
+    .screen.playing .phosphor{
+      opacity:1;
+    }
     .static{
       background-image:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFklEQVQI12P4//8/Az7w+PHjY2BgAACh1A9TJS3BMgAAAABJRU5ErkJggg==');
       image-rendering:pixelated;
-      opacity:.08;
-      mix-blend-mode:overlay;
+      opacity:0; mix-blend-mode:overlay;
       animation:staticShift .2s steps(2) infinite;
-      pointer-events:none;
+      pointer-events:none; transition:opacity var(--dur) var(--ease);
     }
+    .screen.playing .static{ opacity:.08; }
 
     @keyframes scanMove{ from{background-position:0 0;} to{background-position:0 4px;} }
     @keyframes tileFlash{ 0%{opacity:1;} 100%{opacity:0;} }

--- a/styles/shell.css
+++ b/styles/shell.css
@@ -1,4 +1,5 @@
 @import url('base.css');
+@import url('themes.css');
 
 .cabinet{min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:12px; padding:14px;}
 .frame{width:min(520px,94vw); height:min(84vh, 86svh);

--- a/styles/shell.css
+++ b/styles/shell.css
@@ -1,8 +1,8 @@
 @import url('base.css');
 @import url('themes.css');
 
-.cabinet{min-height:100vh; display:flex; flex-direction:column; align-items:center; gap:12px; padding:14px;}
-.frame{width:min(520px,94vw); height:min(84vh, 86svh);
+.cabinet{min-height:100svh; display:flex; flex-direction:column; align-items:center; gap:12px; padding:14px;}
+.frame{width:min(520px,94vw); height:84svh;
   background:linear-gradient(180deg, var(--bg1), #ffc777 60%, #ffb347);
   border-radius:22px; position:relative; padding:12px; box-shadow:
     inset 0 2px 0 var(--bezel-hi),
@@ -20,20 +20,21 @@ canvas{width:100%; height:100%; display:block; image-rendering:pixelated}
 .pad{ position:absolute; left:10px; right:10px; bottom:10px; display:flex; justify-content:center; gap:12px;
   padding:8px; border-radius:12px;
   background:var(--tile-bg); border:2px solid var(--bezel); box-shadow:inset 0 2px 0 var(--bezel-hi), inset 0 -3px 0 var(--bezel); }
+.pad button{min-width:clamp(56px,18vw,80px);min-height:clamp(56px,18vw,80px);font-size:clamp(12px,4vw,16px);}
 .pad.hidden{display:none}
 .pad-toggle{position:absolute; right:10px; bottom:10px; display:none}
 .pad-toggle.show{display:block}
-.dpad{ width:40vw; max-width:260px; aspect-ratio:1; display:grid; grid-template-areas:
+.dpad{ width:min(40vw,40svh); max-width:260px; aspect-ratio:1; display:grid; grid-template-areas:
     ". up ."
     "left mid right"
     ". down .";
   gap:8px; padding:10px; border-radius:16px;
   background:var(--tile-bg); border:2px solid var(--bezel); box-shadow:inset 0 2px 0 var(--bezel-hi), inset 0 -3px 0 var(--bezel); }
 .k{ background:linear-gradient(var(--tile-bg), var(--tile-bg-dim)); border:2px solid var(--bezel); border-radius:12px;
-  box-shadow:0 4px 0 var(--bezel-lo),0 6px 12px rgba(0,0,0,.25); height:20vw; max-height:80px;
+  box-shadow:0 4px 0 var(--bezel-lo),0 6px 12px rgba(0,0,0,.25);
   display:flex; align-items:center; justify-content:center; font-family:'Press Start 2P', ui-monospace, monospace;
-  font-size:12px; transition:transform .1s, filter .1s; }
-.dpad .k{height:100%}
+  transition:transform .1s, filter .1s; }
+.dpad .k{width:100%;height:100%;min-width:56px;min-height:56px;}
 .k.down{ filter:brightness(1.08); transform:translateY(2px); box-shadow:0 2px 0 var(--bezel-lo),0 3px 6px rgba(0,0,0,.2); animation:kglitch .18s steps(2) infinite; }
 
 @keyframes kglitch{
@@ -51,6 +52,6 @@ canvas{width:100%; height:100%; display:block; image-rendering:pixelated}
 @media (max-width:600px){
   .hud{flex-direction:column; align-items:center; text-align:center; gap:4px;}
   .pad{flex-direction:column; align-items:center;}
-  .dpad{width:60vw; max-width:240px;}
+  .dpad{width:min(60vw,40svh); max-width:240px;}
 }
 

--- a/styles/themes.css
+++ b/styles/themes.css
@@ -1,0 +1,11 @@
+/* Theme palettes for games */
+.theme-blue {
+  --bg0: var(--bg);
+  --bg1: var(--bg2);
+  --bg2: var(--panel);
+  --pastel-pink: var(--accent);
+  --pastel-blue: var(--accent2);
+  --pastel-mint: var(--hi);
+  --pastel-peach: var(--panel);
+  --accent: var(--accent2);
+}


### PR DESCRIPTION
## Summary
- create and destroy game iframes on demand instead of preloading
- centralize palette overrides with a reusable `theme-blue` class
- drop Courier New fallback to standardize on Press Start 2P
- replace browser dialogs with custom popups and toasts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b80944d66483328f85821bbbc3f766