### PR TITLE
Fix icon scaling in menu tiles

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -297,10 +297,11 @@ html,body{overflow:hidden;}
       filter:blur(.5px) brightness(.9) contrast(.95);
     }
     .tile canvas{
-      position:relative; overflow:hidden;
+      position:relative;
+      overflow:hidden;
       box-sizing:border-box;
-      width:calc(100% - 12px);
-      height:calc(100% - 12px);
+      width:20px;
+      height:20px;
       image-rendering:pixelated;
       background:#14110e;
       border-radius:12px;


### PR DESCRIPTION
## Summary
- ensure tile icons display at their intended 16x16 size within a frame

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9efc646bc833286e1dd62faa64418