### PR TITLE
refactor: bundle assets for offline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 dist
-

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,19 +1,13 @@
-const cache = {};
+import en from '../i18n/en.json';
+import ru from '../i18n/ru.json';
+import uk from '../i18n/uk.json';
+
+const cache = { en, ru, uk };
 let currentLang = 'en';
 
 export async function setLang(lang){
-  if(cache[lang]){
-    currentLang = lang;
-    document.documentElement.lang = lang;
-    localStorage.setItem('lang', lang);
-    applyTranslations();
-    return;
-  }
-  try {
-    const res = await fetch(`i18n/${lang}.json`);
-    cache[lang] = await res.json();
-  } catch(err){
-    console.warn('i18n load failed', err);
+  if(!cache[lang]){
+    console.warn('i18n load failed');
     cache[lang] = {};
     const warn=document.createElement('div');
     warn.textContent='Failed to load translations.';

--- a/src/icons.js
+++ b/src/icons.js
@@ -1,38 +1,43 @@
+import anim from './icon-data/anim.json';
+import arena from './icon-data/arena.json';
+import breakout from './icon-data/breakout.json';
+import cards from './icon-data/cards.json';
+import music from './icon-data/music.json';
+import pong from './icon-data/pong.json';
+import rain from './icon-data/rain.json';
+import rhythm from './icon-data/rhythm.json';
+import rogue from './icon-data/rogue.json';
+import snake from './icon-data/snake.json';
+import tower from './icon-data/tower.json';
+
+const modules = { anim, arena, breakout, cards, music, pong, rain, rhythm, rogue, snake, tower };
+
 (function(){
   'use strict';
 
-  const cache = {}, pending = {}, items = [];
+  const cache = {}, items = [];
   let frame = 0, last = 0, fps = 12, animating = false;
 
   async function load(name){
     if(cache[name]) return cache[name];
-    if(pending[name]) return pending[name];
-    pending[name] = fetch(`src/icon-data/${name}.json`)
-      .then(r=>r.json())
-      .then(sets=>{
-        const canvases = sets.map(data=>{
-          const cv = document.createElement('canvas');
-          cv.width = 16; cv.height = 16;
-          const ctx = cv.getContext('2d',{alpha:false});
-          ctx.imageSmoothingEnabled = false;
-          let minX=1e9,minY=1e9,maxX=-1e9,maxY=-1e9;
-          data.forEach(p=>{ if(p.x<minX) minX=p.x; if(p.y<minY) minY=p.y; if(p.x>maxX) maxX=p.x; if(p.y>maxY) maxY=p.y; });
-          const w=maxX-minX+1, h=maxY-minY+1;
-          const offX=Math.floor((16-w)/2), offY=Math.floor((16-h)/2);
-          data.forEach(p=>{
-            ctx.fillStyle=p.c;
-            ctx.fillRect(p.x-minX+offX, p.y-minY+offY,1,1);
-          });
-          return cv;
-        });
-        while(canvases.length < 10 && canvases.length > 0){
-          canvases.push(...canvases);
-        }
-        cache[name] = canvases.slice(0, Math.max(10, canvases.length));
-        delete pending[name];
-        return cache[name];
-      });
-    return pending[name];
+    const sets = modules[name] || [];
+    const canvases = sets.map(data=>{
+      const cv = document.createElement('canvas');
+      cv.width = 16; cv.height = 16;
+      const ctx = cv.getContext('2d',{alpha:false});
+      ctx.imageSmoothingEnabled = false;
+      let minX=1e9,minY=1e9,maxX=-1e9,maxY=-1e9;
+      data.forEach(p=>{ if(p.x<minX) minX=p.x; if(p.y<minY) minY=p.y; if(p.x>maxX) maxX=p.x; if(p.y>maxY) maxY=p.y; });
+      const w=maxX-minX+1, h=maxY-minY+1;
+      const offX=Math.floor((16-w)/2), offY=Math.floor((16-h)/2);
+      data.forEach(p=>{ ctx.fillStyle=p.c; ctx.fillRect(p.x-minX+offX, p.y-minY+offY,1,1); });
+      return cv;
+    });
+    while(canvases.length < 10 && canvases.length > 0){
+      canvases.push(...canvases);
+    }
+    cache[name] = canvases.slice(0, Math.max(10, canvases.length));
+    return cache[name];
   }
 
   function draw(ctx,name,frame){
@@ -56,7 +61,7 @@
     const ctx = canvas.getContext('2d',{alpha:false});
     ctx.imageSmoothingEnabled = false;
     items.push({ctx,name});
-    (cache[name] ? Promise.resolve(cache[name]) : load(name)).then(()=>draw(ctx,name,frame));
+    load(name).then(()=>draw(ctx,name,frame));
     if(!animating){ animating = true; requestAnimationFrame(loop); }
   }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,31 @@
 import { defineConfig } from 'vite';
+import { resolve } from 'path';
 import viteImagemin from 'vite-plugin-imagemin';
 import viteCompression from 'vite-plugin-compression';
 
 export default defineConfig({
   root: '.',
+  base: './',
   build: {
     outDir: 'dist',
-    minify: 'esbuild'
+    minify: 'esbuild',
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        avatar: resolve(__dirname, 'avatar-editor.html'),
+        arena: resolve(__dirname, 'arena.html'),
+        dodge: resolve(__dirname, 'dodge-rain.html'),
+        memory: resolve(__dirname, 'memory-flip.html'),
+        miniRogue: resolve(__dirname, 'mini-rogue.html'),
+        music: resolve(__dirname, 'music-box.html'),
+        animator: resolve(__dirname, 'pixel-animator.html'),
+        pong: resolve(__dirname, 'pixel-pong.html'),
+        snake: resolve(__dirname, 'pixel-snake.html'),
+        breakout: resolve(__dirname, 'retro-breakout.html'),
+        rhythm: resolve(__dirname, 'rhythm.html'),
+        tower: resolve(__dirname, 'tower.html')
+      }
+    }
   },
   plugins: [
     viteImagemin({


### PR DESCRIPTION
## Summary
- embed translations and icon data directly in scripts to remove network fetches
- load games via iframe instead of fetching HTML
- configure Vite build with relative base and multiple entry points
- hide Chromium `--no-sandbox` banner for cleaner game display
- drop built `dist` artifacts and ignore future build output

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba9e364a7083329fbad17cfdc150ac