### PR TITLE
Fix icon canvas sizing for game cartridges

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -298,12 +298,12 @@ html,body{overflow:hidden;}
     }
     .tile canvas{
       position:relative; overflow:hidden;
-      box-sizing:border-box;
-      width:calc(100% - 12px);
-      height:calc(100% - 12px);
+      box-sizing:content-box;
+      width:16px;
+      height:16px;
       image-rendering:pixelated;
       background:#14110e;
-      border-radius:12px;
+      border-radius:4px;
       border:2px solid #ffbd69;
       box-shadow:inset 0 0 0 2px #ffd59e,0 0 0 1px rgba(0,0,0,.12);
       transform:scale(1);


### PR DESCRIPTION
## Summary
- enforce 16×16 canvas size for icon animations to avoid stretching
- adjust cartridge styling to use content-box and small border radius

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc11f9e1688332867409fce975e49d